### PR TITLE
Missing delegate to stop screen sharing work when app is closed

### DIFF
--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -41,7 +41,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, RCTBridgeDelegate {
       return true
   }
   
-
+  func applicationWillTerminate(_ application: UIApplication) {
+    BigBlueButtonSDK.onAppTerminated()
+  }
 
   func sourceURL(for bridge: RCTBridge!) -> URL! {
 //#if DEBUG


### PR DESCRIPTION
# What does this PR do?
- Added the missing delegate to stop the broadcast extension when the app closes