### PR TITLE
Resolving promise reject when async storage is null

### DIFF
--- a/react-native/app/routes/component.tsx
+++ b/react-native/app/routes/component.tsx
@@ -51,8 +51,22 @@ const DeepLink = ()=>{
   }
 
   async function checkIfHaveTemporaryPortal(){
-    const portalsFromStorage = await AsyncStorage.getItem('portal')
-    const portalsParsed = JSON.parse(portalsFromStorage)
+    let portalsParsed: IPortal[]|null = null;
+    try {
+      let items = await AsyncStorage.getAllKeys();
+      if (items.includes('portal')) {
+        const portalsFromStorage = await AsyncStorage.getItem('portal')
+        portalsParsed = portalsFromStorage ?  JSON.parse(portalsFromStorage) : null
+      } else {
+        console.log('Error: Dont Have Portals Storage');
+      }
+    } catch (e) {
+      console.log('error', e);
+    }
+          
+    if(!portalsParsed){
+      return 
+    }
     const portalsWithoutTemporary = portalsParsed.filter((portal: IPortal)=>{
       if(portal.temporary == true) return false
       if(portal.name == NAME_PORTALS_DEEP_LINK) return false


### PR DESCRIPTION
# What does this PR do? 
- it fixes the problem when portals in AsyncStorage is null 
![image](https://user-images.githubusercontent.com/59415818/174426192-f0245691-fcd2-4f4e-9a25-08efd5457d94.png)
